### PR TITLE
Fix frameskip bug and add Minitaur controllers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && apt-get install -y \
 	apt-get autoremove && \
 	rm -rf /var/cache/apk/*
 
-RUN  apt-get install -y vim wget unzip 
+RUN  apt-get install -y vim wget unzip tmux
 
 RUN  apt-get install -y libzmq3-dev
 

--- a/examples/configs/husky_navigate_rgb_train.yaml
+++ b/examples/configs/husky_navigate_rgb_train.yaml
@@ -8,7 +8,7 @@ fov: 1.57
 is_discrete: true
 
 use_filler: true
-display_ui: false
+display_ui: true
 show_diagnostics: true
 ui_num: 1
 ui_components: [RGB_FILLED]
@@ -25,7 +25,7 @@ resolution: 128
 
 speed:
   timestep: 0.001
-  frameskip: 10
+  frameskip: 100
 
-mode: headless #gui|headless
+mode: gui #gui|headless
 verbose: false

--- a/examples/configs/minitaur_navigate_nonviz.yaml
+++ b/examples/configs/minitaur_navigate_nonviz.yaml
@@ -10,8 +10,8 @@ is_discrete: false
 use_filler: true
 display_ui: true
 show_diagnostics: false
-ui_num: 2
-ui_components: [RGB_FILLED, DEPTH]
+ui_num: 1
+ui_components: [RGB_FILLED]
 random:
   random_initial_pose : false
   random_target_pose : false
@@ -20,12 +20,13 @@ random:
   random_init_z_range: [-0.1, 0.1]
   random_init_rot_range: [-0.1, 0.1]
 
-output: [nonviz_sensor]
-resolution: 256
+output: [nonviz_sensor, rgb_filled]
+resolution: 128
 
 speed:
   timestep: 0.001
-  frameskip: 1
+  frameskip: 100
 
 mode: gui #gui|headless
 verbose: false
+fast_lq_render: true

--- a/examples/configs/minitaur_navigate_nonviz.yaml
+++ b/examples/configs/minitaur_navigate_nonviz.yaml
@@ -29,4 +29,3 @@ speed:
 
 mode: gui #gui|headless
 verbose: false
-fast_lq_render: true

--- a/examples/demo/controller_minitaur_nonviz.py
+++ b/examples/demo/controller_minitaur_nonviz.py
@@ -50,12 +50,14 @@ class SinePolicyController:
       amplitude1 = self.amplitude_1_bound
       amplitude2 = self.amplitude_2_bound
       steering_amplitude = 0
+      """
       if t < 10:
         steering_amplitude = 0.1
       elif t < 20:
         steering_amplitude = -0.1
       else:
         steering_amplitude = 0
+     """
 
       # Applying asymmetrical sine gaits to different legs can steer the minitaur.
       a1 = math.sin(t * self.speed) * (amplitude1 + steering_amplitude)
@@ -132,8 +134,10 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     env = MinitaurNavigateEnv(config = args.config)
-    controller = SinePolicyLeftController()
+    #controller = SinePolicyController()
 
     env.reset()
+    action = [0]*8
     while True:
-      controller.act(env)
+      #controller.act(env)
+      env.step(action)

--- a/gibson/core/physics/drivers/minitaur.py
+++ b/gibson/core/physics/drivers/minitaur.py
@@ -61,7 +61,6 @@ class MinitaurBase(WalkerBase):
     applied_motor_torques = np.zeros(num_motors)
     max_force = 5.5
     joint_name_to_id = None
-    controller = None
         
     """The minitaur class that simulates a quadruped robot from Ghost Robotics.
     """
@@ -397,6 +396,8 @@ class MinitaurBase(WalkerBase):
         Args:
           motor_commands: The eight desired motor angles.
         """
+        if self.controller:
+            motor_commands = self.controller.translate_action_to_motor_commands(motor_commands)
         #print("motor commands 1", motor_commands)
         if self.motor_velocity_limit < np.inf:
             current_motor_angle = self.GetMotorAngles()

--- a/gibson/core/physics/drivers/minitaur.py
+++ b/gibson/core/physics/drivers/minitaur.py
@@ -7,6 +7,7 @@ import numpy as np
 from gibson.core.physics import motor
 from gibson.core.physics.robot_locomotors import WalkerBase
 from gibson.core.physics.robot_bases import Joint, BodyPart
+from gibson.core.physics.drivers.minitaur_controllers import SinePolicyController
 import os, sys
 import pybullet as p
 import gym
@@ -60,13 +61,15 @@ class MinitaurBase(WalkerBase):
     applied_motor_torques = np.zeros(num_motors)
     max_force = 5.5
     joint_name_to_id = None
+    controller = None
         
     """The minitaur class that simulates a quadruped robot from Ghost Robotics.
     """
 
     def __init__(self, config, env=None,
                  pd_control_enabled=True,
-                 accurate_motor_model_enabled=True):
+                 accurate_motor_model_enabled=True,
+                 use_sine_controller=True):
         """Constructs a minitaur and reset it to the initial states.
 
         Properties:
@@ -120,6 +123,9 @@ class MinitaurBase(WalkerBase):
         else:
             self._kp = 1
             self._kd = 1
+
+        if use_sine_controller:
+            self.controller = SinePolicyController(self)
 
         if config["is_discrete"]:
             self.action_space = gym.spaces.Discrete(17)

--- a/gibson/core/physics/drivers/minitaur.py
+++ b/gibson/core/physics/drivers/minitaur.py
@@ -7,7 +7,7 @@ import numpy as np
 from gibson.core.physics import motor
 from gibson.core.physics.robot_locomotors import WalkerBase
 from gibson.core.physics.robot_bases import Joint, BodyPart
-from gibson.core.physics.drivers.minitaur_controllers import SinePolicyController
+from gibson.core.physics.drivers.minitaur_controllers import ForwardSinePolicyController
 import os, sys
 import pybullet as p
 import gym
@@ -124,7 +124,7 @@ class MinitaurBase(WalkerBase):
             self._kd = 1
 
         if use_sine_controller:
-            self.controller = SinePolicyController(time_step=self.time_step)
+            self.controller = ForwardSinePolicyController(time_step=self.time_step)
 
         if config["is_discrete"]:
             self.action_space = gym.spaces.Discrete(17)

--- a/gibson/core/physics/drivers/minitaur.py
+++ b/gibson/core/physics/drivers/minitaur.py
@@ -68,7 +68,7 @@ class MinitaurBase(WalkerBase):
     def __init__(self, config, env=None,
                  pd_control_enabled=True,
                  accurate_motor_model_enabled=True,
-                 use_sine_controller=True):
+                 use_controller='forward'):
         """Constructs a minitaur and reset it to the initial states.
 
         Properties:
@@ -123,8 +123,11 @@ class MinitaurBase(WalkerBase):
             self._kp = 1
             self._kd = 1
 
-        if use_sine_controller:
-            self.controller = ForwardSinePolicyController(time_step=self.time_step)
+        if use_controller:
+            if use_controller == 'forward':
+                self.controller = ForwardSinePolicyController(time_step=self.time_step)
+            elif use_controller == 'vector':
+                self.controller = VectorSinePolicyController(time_step=self.time_step)
 
         if config["is_discrete"]:
             self.action_space = gym.spaces.Discrete(17)

--- a/gibson/core/physics/drivers/minitaur.py
+++ b/gibson/core/physics/drivers/minitaur.py
@@ -124,7 +124,7 @@ class MinitaurBase(WalkerBase):
             self._kd = 1
 
         if use_sine_controller:
-            self.controller = SinePolicyController(self)
+            self.controller = SinePolicyController(time_step=self.time_step)
 
         if config["is_discrete"]:
             self.action_space = gym.spaces.Discrete(17)
@@ -398,6 +398,7 @@ class MinitaurBase(WalkerBase):
         """
         if self.controller:
             motor_commands = self.controller.translate_action_to_motor_commands(motor_commands)
+            motor_commands = self.ConvertFromLegModel(motor_commands)
         #print("motor commands 1", motor_commands)
         if self.motor_velocity_limit < np.inf:
             current_motor_angle = self.GetMotorAngles()

--- a/gibson/core/physics/drivers/minitaur_controllers.py
+++ b/gibson/core/physics/drivers/minitaur_controllers.py
@@ -12,24 +12,26 @@ class SinePolicyController:
         self.time_step = time_step
         self.t = 0
 
-    def translate_action_to_motor_commands(self, a):
+    def get_motor_commands(self, amplitude_1, amplitude_2):
         self.t = self.step_count * self.time_step
-        actions = self.get_motor_commands()
-        self.step_count = self.step_count + 1
-        return actions
 
-    def get_motor_commands(self):
-        w1 = .7
-        w2 = .7
-
-        a1 = math.sin(self.t * self.period) * w1
-        a2 = math.sin(self.t * self.period + math.pi) * w2
-        a3 = math.sin(self.t * self.period) * w2
-        a4 = math.sin(self.t * self.period + math.pi) * w1
+        a1 = math.sin(self.t * self.period) * amplitude_1
+        a2 = math.sin(self.t * self.period + math.pi) * amplitude_2
+        a3 = math.sin(self.t * self.period) * amplitude_2
+        a4 = math.sin(self.t * self.period + math.pi) * amplitude_1
 
         action = [a1, a2, a2, a1, a3, a4, a4, a3]
 
+        self.step_count = self.step_count + 1
+
         return action
+
+class ForwardSinePolicyController(SinePolicyController):
+    def __init__(self, time_step=.001):
+        SinePolicyController.__init__(self, time_step=time_step)
+
+    def translate_action_to_motor_commands(self, a):
+        return self.get_motor_commands(.7, .7)
 
 class VelocitySinePolicyController:
     """Have minitaur walk with a sine gait."""

--- a/gibson/core/physics/drivers/minitaur_controllers.py
+++ b/gibson/core/physics/drivers/minitaur_controllers.py
@@ -1,0 +1,69 @@
+import numpy as np
+import math
+
+class SinePolicyController:
+    """Have minitaur walk with a sine gait."""
+    # Leg model enabled
+    # Accurate model enabled
+    # pd control enabled
+    def __init__(self, robot):
+        self.period = 40
+        self.step_count = 0
+        self.time_step = 0.001
+        self.t = 0
+        self.robot = robot
+
+    def translate_action_to_motor_commands(self, a):
+        self.t = self.step_count * self.time_step
+        actions = self.get_motor_commands()
+        self.step_count = self.step_count + 1
+        return actions
+
+    def get_motor_commands(self):
+        w1 = .7
+        w2 = .7
+
+        a1 = math.sin(self.t * self.period) * w1
+        a2 = math.sin(self.t * self.period + math.pi) * w2
+        a3 = math.sin(self.t * self.period) * w2
+        a4 = math.sin(self.t * self.period + math.pi) * w1
+
+        action = [a1, a2, a2, a1, a3, a4, a4, a3]
+
+        action = self.robot.ConvertFromLegModel(action)
+        return action
+
+class VelocitySinePolicyController:
+    """Have minitaur walk with a sine gait."""
+    # Leg model enabled
+    # Accurate model enabled
+    # pd control enabled
+    def __init__(self):
+        self.period = 60
+        self.step_count = 0
+        self.time_step = 0.001
+        self.t = 0
+
+    def translate_action_to_motor_commands(self, velocity_vec):
+        self.t = self.step_count * self.time_step
+        phi, r = velocity_vec
+        # this constant translates +- pi/2 constraint to +- 3 steering amplitude
+        c = -6. / math.pi
+        steering_amplitude = c*phi
+        actions = self.get_motor_commands(r, steering_amplitude)
+        self.step_count = self.step_count + 1
+        return actions
+
+    def get_motor_commands(self, r, steering_amplitude):
+        # Applying asymmetrical sine gaits to different legs can steer the minitaur
+        # Legs need minimum amplitude to move
+        w1 = max(r + steering_amplitude, .5)
+        w2 = max(r - steering_amplitude, .5)
+
+        a1 = math.sin(self.t * self.period) * w1
+        a2 = math.sin(self.t * self.period + math.pi) * w2
+        a3 = math.sin(self.t * self.period) * w2
+        a4 = math.sin(self.t * self.period + math.pi) * w1
+
+        action = [a1, a2, a2, a1, a3, a4, a4, a3]
+        return action

--- a/gibson/core/physics/drivers/minitaur_controllers.py
+++ b/gibson/core/physics/drivers/minitaur_controllers.py
@@ -6,12 +6,11 @@ class SinePolicyController:
     # Leg model enabled
     # Accurate model enabled
     # pd control enabled
-    def __init__(self, robot):
+    def __init__(self, time_step=.001):
         self.period = 40
         self.step_count = 0
-        self.time_step = 0.001
+        self.time_step = time_step
         self.t = 0
-        self.robot = robot
 
     def translate_action_to_motor_commands(self, a):
         self.t = self.step_count * self.time_step
@@ -30,7 +29,6 @@ class SinePolicyController:
 
         action = [a1, a2, a2, a1, a3, a4, a4, a3]
 
-        action = self.robot.ConvertFromLegModel(action)
         return action
 
 class VelocitySinePolicyController:

--- a/gibson/core/physics/drivers/minitaur_controllers.py
+++ b/gibson/core/physics/drivers/minitaur_controllers.py
@@ -33,37 +33,15 @@ class ForwardSinePolicyController(SinePolicyController):
     def translate_action_to_motor_commands(self, a):
         return self.get_motor_commands(.7, .7)
 
-class VelocitySinePolicyController:
-    """Have minitaur walk with a sine gait."""
-    # Leg model enabled
-    # Accurate model enabled
-    # pd control enabled
-    def __init__(self):
-        self.period = 60
-        self.step_count = 0
-        self.time_step = 0.001
-        self.t = 0
+class VectorSinePolicyController(SinePolicyController):
+    def __init__(self, time_step=.001):
+        SinePolicyController.__init__(self, time_step=time_step)
 
-    def translate_action_to_motor_commands(self, velocity_vec):
-        self.t = self.step_count * self.time_step
-        phi, r = velocity_vec
+    def translate_action_to_motor_commands(self, a):
+        phi, r = a
         # this constant translates +- pi/2 constraint to +- 3 steering amplitude
         c = -6. / math.pi
         steering_amplitude = c*phi
-        actions = self.get_motor_commands(r, steering_amplitude)
-        self.step_count = self.step_count + 1
-        return actions
-
-    def get_motor_commands(self, r, steering_amplitude):
-        # Applying asymmetrical sine gaits to different legs can steer the minitaur
-        # Legs need minimum amplitude to move
-        w1 = max(r + steering_amplitude, .5)
-        w2 = max(r - steering_amplitude, .5)
-
-        a1 = math.sin(self.t * self.period) * w1
-        a2 = math.sin(self.t * self.period + math.pi) * w2
-        a3 = math.sin(self.t * self.period) * w2
-        a4 = math.sin(self.t * self.period + math.pi) * w1
-
-        action = [a1, a2, a2, a1, a3, a4, a4, a3]
-        return action
+        amplitude_1 = max(r + steering_amplitude, .5)
+        amplitude_2 = max(r - steering_amplitude, .5)
+        return self.get_motor_commands(amplitude_1, amplitude_2)

--- a/gibson/core/physics/robot_bases.py
+++ b/gibson/core/physics/robot_bases.py
@@ -48,6 +48,7 @@ class BaseRobot:
         self.scale = scale
         self._load_model()
         self.eyes = self.parts["eyes"]
+        self.controller = None
         
         self.env = env
 

--- a/gibson/core/physics/scene_abstract.py
+++ b/gibson/core/physics/scene_abstract.py
@@ -14,7 +14,8 @@ class Scene:
         self.frame_skip = frame_skip
         self.env = env
 
-        self.dt = self.timestep * self.frame_skip
+        #self.dt = self.timestep * self.frame_skip
+        self.dt = self.timestep
         self.cpp_world = World(gravity, timestep, frame_skip)
 
         self.test_window_still_open = True  # or never opened
@@ -68,7 +69,8 @@ class World:
         #p.resetSimulation()
         p.setGravity(0, 0, -self.gravity)
         #p.setDefaultContactERP(0.9)
-        p.setPhysicsEngineParameter(fixedTimeStep=self.timestep*self.frame_skip, numSolverIterations=50, numSubSteps=(self.frame_skip-1))
+        #p.setPhysicsEngineParameter(fixedTimeStep=self.timestep*self.frame_skip, numSolverIterations=50, numSubSteps=(self.frame_skip-1))
+        p.setPhysicsEngineParameter(fixedTimeStep=self.timestep, numSolverIterations=50)
 
     def step(self, frame_skip):
         if self._is_render:

--- a/gibson/core/physics/scene_abstract.py
+++ b/gibson/core/physics/scene_abstract.py
@@ -14,8 +14,6 @@ class Scene:
         self.frame_skip = frame_skip
         self.env = env
 
-        #self.dt = self.timestep * self.frame_skip
-        self.dt = self.timestep
         self.cpp_world = World(gravity, timestep, frame_skip)
 
         self.test_window_still_open = True  # or never opened
@@ -69,7 +67,6 @@ class World:
         #p.resetSimulation()
         p.setGravity(0, 0, -self.gravity)
         #p.setDefaultContactERP(0.9)
-        #p.setPhysicsEngineParameter(fixedTimeStep=self.timestep*self.frame_skip, numSolverIterations=50, numSubSteps=(self.frame_skip-1))
         p.setPhysicsEngineParameter(fixedTimeStep=self.timestep, numSolverIterations=50)
 
     def step(self, frame_skip):

--- a/gibson/envs/env_modalities.py
+++ b/gibson/envs/env_modalities.py
@@ -185,11 +185,7 @@ class BaseRobotEnv(BaseEnv):
         self.nframe += 1
         if not self.scene.multiplayer:  # if multiplayer, action first applied to all robots, then global step() called, then _step() for all robots with the same actions
             for _ in range(self.frame_skip):
-                if self.robot.controller:
-                    motor_commands = self.robot.controller.translate_action_to_motor_commands(a)
-                else:
-                    motor_commands = a
-                self.robot.apply_action(motor_commands)
+                self.robot.apply_action(a)
                 self.scene.global_step()
 
         self.rewards = self._rewards(a)

--- a/gibson/envs/minitaur_env.py
+++ b/gibson/envs/minitaur_env.py
@@ -177,7 +177,7 @@ class MinitaurNavigateEnv(CameraRobotEnv):
           ValueError: The magnitude of actions is out of bounds.
         """
         #print("Env apply raw action", action)
-        action = self._transform_action_to_motor_command(action)
+        #action = self._transform_action_to_motor_command(action)
         #print("Env apply action", action)
     
         #for _ in range(self._action_repeat):

--- a/gibson/utils/ppo2.py
+++ b/gibson/utils/ppo2.py
@@ -221,8 +221,10 @@ def learn(*, policy, env, nsteps, total_timesteps, ent_coef, lr,
     if save_interval and logger.get_dir():
         import cloudpickle
         base_path = os.path.dirname(os.path.abspath(__file__))
-        print(base_path)
-        with open(osp.join(base_path, "models", 'make_model.pkl'), 'wb') as fh:
+        model_path = osp.join(base_path, "models")
+        print(model_path)
+        os.makedirs(model_path, exist_ok=True)
+        with open(osp.join(model_path, 'make_model.pkl'), 'wb') as fh:
             fh.write(cloudpickle.dumps(make_model))
     
     model = make_model()


### PR DESCRIPTION
Fixed frameskip bug as described in #47 .  I added a `controller = None` property to `BaseRobot`, then in  `BaseRobotEnv._step`, we loop `frame_skip` times on transforming the action `a` with the controller (or pass through if none exists). Pybullet simulates for `timestep` time in each loop iteration.

Verified working with Minitaur, Husky, and drone at frameskips of 1, 10, and 100.